### PR TITLE
Publish a basic Arch Linux container image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,8 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.4.1
+    steps:
+      - checkout
+      - run: echo "A first hello"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,9 +25,9 @@ jobs:
           name: Add projectatomic repository
           command: |
             sudo apt-get update -qq
-            sudo apt-get install -qq -y software-properties-common
+            sudo apt-get install -qq software-properties-common
             sudo add-apt-repository -y ppa:projectatomic/ppa
             sudo apt-get update -qq
       - run:
           name: Install buildah
-          command: sudo apt-get -qq -y install buildah
+          command: sudo apt-get -qq install buildah

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
             echo 'export ARCHITECTURE="x86_64"' >> $BASH_ENV
             echo 'export FILENAME="archlinux-bootstrap-${DATE}-${ARCHITECTURE}.tar.gz"' >> $BASH_ENV
             echo 'export URL_PATH="https://archive.archlinux.org/iso/${DATE}"' >> $BASH_ENV
+            echo 'export CONTAINER="arch"' >> $BASH_ENV
       - run:
           name: Download Arch Linux bootstrap tarball
           command: >
@@ -32,3 +33,12 @@ jobs:
       - run:
           name: Install buildah
           command: sudo apt-get -qq install buildah
+      - run:
+          name: Extract tarball to a new empty container
+          shell: sudo /bin/bash -eo pipefail
+          command: |
+            buildah from --name $CONTAINER scratch
+            ROOT_FS=$(buildah mount $CONTAINER)
+            tar xz -f $FILENAME --strip-components=1 -C $ROOT_FS
+            buildah config --cmd /bin/bash $CONTAINER
+            buildah unmount $CONTAINER

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
             echo "export SHA1SUMS=sha1sums.txt" >> $BASH_ENV
             echo "export CONTAINER=arch" >> $BASH_ENV
             echo "export IMAGE_REF=docker://${REGISTRY}/${REPOSITORY}:${FIRST_OF_MONTH_DATE}" >> $BASH_ENV
+            echo "export REGISTRY_AUTH_FILE=${CIRCLE_WORKING_DIRECTORY}/auth.json" >> $BASH_ENV
             cat < $BASH_ENV | sudo tee -a /root/.profile
       - run:
           name: Download Arch Linux bootstrap tarball and checksum
@@ -50,11 +51,11 @@ jobs:
             buildah config --cmd /bin/bash $CONTAINER
             buildah unmount $CONTAINER
       - run:
-          name: Create image from container and push it to registry
-          <<: *sudo_shell
-          command: |
-            echo $REGISTRY_PWD | buildah login -u $REGISTRY_USER --password-stdin $REGISTRY
-            buildah commit $CONTAINER $IMAGE_REF
+          name: Login to container registry
+          command: echo $REGISTRY_PWD | buildah login -u $REGISTRY_USER --password-stdin $REGISTRY
       - run:
-          name: Inspect result
-          command: sudo skopeo inspect $IMAGE_REF
+          name: Create image from container and push it to registry
+          command: sudo buildah commit --authfile $REGISTRY_AUTH_FILE $CONTAINER $IMAGE_REF
+      - run:
+          name: Inspect pushed image on registry
+          command: skopeo inspect --authfile $REGISTRY_AUTH_FILE $IMAGE_REF

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,3 +45,12 @@ jobs:
             tar xz -f $FILENAME --strip-components=1 -C $ROOT_FS
             buildah config --cmd /bin/bash $CONTAINER
             buildah unmount $CONTAINER
+      - run:
+          name: Create image from container and push it to registry
+          <<: *sudo_shell
+          command: |
+            echo $REGISTRY_PWD | buildah login -u $REGISTRY_USER --password-stdin $REGISTRY
+            buildah commit $CONTAINER docker://${REGISTRY}/${REPOSITORY}:${DATE}
+      - run:
+          name: Inspect result
+          command: sudo skopeo inspect docker://${REGISTRY}/${REPOSITORY}:${DATE}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
             add-apt-repository -y ppa:projectatomic/ppa
             apt-get update
       - run:
-          name: Install buildah
-          command: sudo apt-get -y install buildah
+          name: Install buildah and skopeo
+          command: sudo apt-get -y install buildah skopeo
       - run:
           name: Extract tarball to a new empty container
           <<: *sudo_shell

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,23 @@
 version: 2
 jobs:
   build:
-    docker:
-      - image: circleci/ruby:2.4.1
+    machine:
+      image: ubuntu-1604:201903-01
     steps:
-      - checkout
-      - run: echo "A first hello"
+      - run:
+          name: Setup environment variables
+          command: |
+            echo 'export DATE=$(date +"%Y.%m.01")' >> $BASH_ENV
+            echo 'export ARCHITECTURE="x86_64"' >> $BASH_ENV
+            echo 'export FILENAME="archlinux-bootstrap-${DATE}-${ARCHITECTURE}.tar.gz"' >> $BASH_ENV
+            echo 'export URL_PATH="https://archive.archlinux.org/iso/${DATE}"' >> $BASH_ENV
+      - run:
+          name: Download Arch Linux bootstrap tarball
+          command: >
+            wget
+            ${URL_PATH}/${FILENAME}
+            ${URL_PATH}/${FILENAME}.sig
+            ${URL_PATH}/sha1sums.txt
+      - run:
+          name: Check file integrity
+          command: grep $FILENAME sha1sums.txt | sha1sum -c -

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,13 +29,13 @@ jobs:
           name: Add projectatomic repository
           <<: *sudo_shell
           command: |
-            apt-get update -qq
-            apt-get install -qq software-properties-common
+            apt-get update
+            apt-get -y install software-properties-common
             add-apt-repository -y ppa:projectatomic/ppa
-            apt-get update -qq
+            apt-get update
       - run:
           name: Install buildah
-          command: sudo apt-get -qq install buildah
+          command: sudo apt-get -y install buildah
       - run:
           name: Extract tarball to a new empty container
           <<: *sudo_shell

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,7 @@
 superuser: &sudo_shell
-  shell: sudo /bin/bash -eo pipefail
+  shell: sudo -EH /bin/bash -leo pipefail
+  environment:
+    - BASH_ENV: "~/.profile"
 
 version: 2
 jobs:
@@ -15,6 +17,7 @@ jobs:
             echo 'export FILENAME="archlinux-bootstrap-${DATE}-${ARCHITECTURE}.tar.gz"' >> $BASH_ENV
             echo 'export URL_PATH="https://archive.archlinux.org/iso/${DATE}"' >> $BASH_ENV
             echo 'export CONTAINER="arch"' >> $BASH_ENV
+            cat < $BASH_ENV | sudo tee -a /root/.profile
       - run:
           name: Download Arch Linux bootstrap tarball
           command: >

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,21 +13,22 @@ jobs:
           name: Setup environment variables
           command: |
             FIRST_OF_MONTH_DATE=$(date +'%Y.%m.01')
-            echo "export FILENAME=archlinux-bootstrap-${FIRST_OF_MONTH_DATE}-x86_64.tar.gz" >> $BASH_ENV
-            echo "export URL_PATH=https://archive.archlinux.org/iso/${FIRST_OF_MONTH_DATE}" >> $BASH_ENV
+            echo "export BASE_URL=https://archive.archlinux.org/iso/${FIRST_OF_MONTH_DATE}/" >> $BASH_ENV
+            echo "export TARBALL=archlinux-bootstrap-${FIRST_OF_MONTH_DATE}-x86_64.tar.gz" >> $BASH_ENV
+            echo "export SHA1SUMS=sha1sums.txt" >> $BASH_ENV
             echo "export CONTAINER=arch" >> $BASH_ENV
             echo "export IMAGE_REF=${REGISTRY}/${REPOSITORY}:${FIRST_OF_MONTH_DATE}" >> $BASH_ENV
             cat < $BASH_ENV | sudo tee -a /root/.profile
       - run:
-          name: Download Arch Linux bootstrap tarball
-          command: >
-            wget
-            ${URL_PATH}/${FILENAME}
-            ${URL_PATH}/${FILENAME}.sig
-            ${URL_PATH}/sha1sums.txt
+          name: Download Arch Linux bootstrap tarball and checksum
+          command: |
+            cat <<EOF | wget --base="$BASE_URL" -i -
+            $TARBALL
+            $SHA1SUMS
+            EOF
       - run:
           name: Check file integrity
-          command: grep $FILENAME sha1sums.txt | sha1sum -c -
+          command: grep $TARBALL $SHA1SUMS | sha1sum -c -
       - run:
           name: Add projectatomic repository
           <<: *sudo_shell
@@ -45,7 +46,7 @@ jobs:
           command: |
             buildah from --name $CONTAINER scratch
             ROOT_FS=$(buildah mount $CONTAINER)
-            tar xz -f $FILENAME --strip-components=1 -C $ROOT_FS
+            tar xz -f $TARBALL --strip-components=1 -C $ROOT_FS
             buildah config --cmd /bin/bash $CONTAINER
             buildah unmount $CONTAINER
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,6 @@
+superuser: &sudo_shell
+  shell: sudo /bin/bash -eo pipefail
+
 version: 2
 jobs:
   build:
@@ -24,7 +27,7 @@ jobs:
           command: grep $FILENAME sha1sums.txt | sha1sum -c -
       - run:
           name: Add projectatomic repository
-          shell: sudo /bin/bash -eo pipefail
+          <<: *sudo_shell
           command: |
             apt-get update -qq
             apt-get install -qq software-properties-common
@@ -35,7 +38,7 @@ jobs:
           command: sudo apt-get -qq install buildah
       - run:
           name: Extract tarball to a new empty container
-          shell: sudo /bin/bash -eo pipefail
+          <<: *sudo_shell
           command: |
             buildah from --name $CONTAINER scratch
             ROOT_FS=$(buildah mount $CONTAINER)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
             echo "export TARBALL=archlinux-bootstrap-${FIRST_OF_MONTH_DATE}-x86_64.tar.gz" >> $BASH_ENV
             echo "export SHA1SUMS=sha1sums.txt" >> $BASH_ENV
             echo "export CONTAINER=arch" >> $BASH_ENV
-            echo "export IMAGE_REF=${REGISTRY}/${REPOSITORY}:${FIRST_OF_MONTH_DATE}" >> $BASH_ENV
+            echo "export IMAGE_REF=docker://${REGISTRY}/${REPOSITORY}:${FIRST_OF_MONTH_DATE}" >> $BASH_ENV
             cat < $BASH_ENV | sudo tee -a /root/.profile
       - run:
           name: Download Arch Linux bootstrap tarball and checksum

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,12 @@ jobs:
           command: grep $FILENAME sha1sums.txt | sha1sum -c -
       - run:
           name: Add projectatomic repository
+          shell: sudo /bin/bash -eo pipefail
           command: |
-            sudo apt-get update -qq
-            sudo apt-get install -qq software-properties-common
-            sudo add-apt-repository -y ppa:projectatomic/ppa
-            sudo apt-get update -qq
+            apt-get update -qq
+            apt-get install -qq software-properties-common
+            add-apt-repository -y ppa:projectatomic/ppa
+            apt-get update -qq
       - run:
           name: Install buildah
           command: sudo apt-get -qq install buildah

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,11 +12,11 @@ jobs:
       - run:
           name: Setup environment variables
           command: |
-            echo 'export DATE=$(date +"%Y.%m.01")' >> $BASH_ENV
-            echo 'export ARCHITECTURE="x86_64"' >> $BASH_ENV
-            echo 'export FILENAME="archlinux-bootstrap-${DATE}-${ARCHITECTURE}.tar.gz"' >> $BASH_ENV
-            echo 'export URL_PATH="https://archive.archlinux.org/iso/${DATE}"' >> $BASH_ENV
-            echo 'export CONTAINER="arch"' >> $BASH_ENV
+            FIRST_OF_MONTH_DATE=$(date +'%Y.%m.01')
+            echo "export FILENAME=archlinux-bootstrap-${FIRST_OF_MONTH_DATE}-x86_64.tar.gz" >> $BASH_ENV
+            echo "export URL_PATH=https://archive.archlinux.org/iso/${FIRST_OF_MONTH_DATE}" >> $BASH_ENV
+            echo "export CONTAINER=arch" >> $BASH_ENV
+            echo "export IMAGE_REF=${REGISTRY}/${REPOSITORY}:${FIRST_OF_MONTH_DATE}" >> $BASH_ENV
             cat < $BASH_ENV | sudo tee -a /root/.profile
       - run:
           name: Download Arch Linux bootstrap tarball
@@ -53,7 +53,7 @@ jobs:
           <<: *sudo_shell
           command: |
             echo $REGISTRY_PWD | buildah login -u $REGISTRY_USER --password-stdin $REGISTRY
-            buildah commit $CONTAINER docker://${REGISTRY}/${REPOSITORY}:${DATE}
+            buildah commit $CONTAINER $IMAGE_REF
       - run:
           name: Inspect result
-          command: sudo skopeo inspect docker://${REGISTRY}/${REPOSITORY}:${DATE}
+          command: sudo skopeo inspect $IMAGE_REF

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,3 +21,13 @@ jobs:
       - run:
           name: Check file integrity
           command: grep $FILENAME sha1sums.txt | sha1sum -c -
+      - run:
+          name: Add projectatomic repository
+          command: |
+            sudo apt-get update -qq
+            sudo apt-get install -qq -y software-properties-common
+            sudo add-apt-repository -y ppa:projectatomic/ppa
+            sudo apt-get update -qq
+      - run:
+          name: Install buildah
+          command: sudo apt-get -qq -y install buildah


### PR DESCRIPTION
Using a CI service and buildah I want to create a basic Arch Linux image from [latest bootstrap tarball](https://archive.archlinux.org/iso/) and push it to a registry.