### PR TITLE
Move tasks related to container creation to arch_bootstrap role

### DIFF
--- a/provision-container-image.yml
+++ b/provision-container-image.yml
@@ -5,17 +5,6 @@
   tasks:
     - include_role:
         name: arch_bootstrap
-    - name: Create an empty container
-      command: buildah from scratch
-      register: buildah_from
-    - name: Mount container's root filesystem
-      command: buildah mount {{ buildah_from.stdout }}
-      register: buildah_mount
-    - name: Extract bootstrap tarball to mount point
-      unarchive:
-        src: ./archlinux-bootstrap.tar.gz
-        dest: "{{ buildah_mount.stdout }}"
-        extra_opts: [--strip-components=1]
     - name: Login to registry
       command: buildah login -u {{ registry.user }} --password-stdin {{ registry.name }}
       args:

--- a/provision-container-image.yml
+++ b/provision-container-image.yml
@@ -11,5 +11,5 @@
         stdin: "{{ registry.password }}"
     - name: Commit changes in container to an image on the registry
       command: >
-        buildah commit {{ buildah_from.stdout }}
+        buildah commit {{ working_container }}
         docker://{{ registry.name }}/{{ registry.repo }}:{{ release }}

--- a/roles/arch_bootstrap/README.md
+++ b/roles/arch_bootstrap/README.md
@@ -34,9 +34,11 @@ previous_release: "{{ ansible_date_time.date | to_datetime('%Y-%m-%d') | to_day_
 This role sets several facts during execution:
 
 **`release`**
+
 It can be either `current_release` or `previous_release`, depending on which monthly tarball was downloaded.
 
 **`working_container`**
+
 ID of the container that was created. This value is dynamic to avoid collisions with any other container in the environment (e.g. previously created by this role).
 
 License

--- a/roles/arch_bootstrap/README.md
+++ b/roles/arch_bootstrap/README.md
@@ -10,6 +10,7 @@ Role Variables
 
 ```yaml
 base_url: https://archive.archlinux.org/iso
+path_to_bootstrap: "{{ playbook_dir }}/archlinux-bootstrap.tar.gz"
 ```
 
 ### vars
@@ -23,7 +24,13 @@ previous_release: "{{ ansible_date_time.date | to_datetime('%Y-%m-%d') | to_day_
 ```
 
 ### facts
-This role sets a fact called `release` depending on which monthly tarball was downloaded.
+This role sets several facts during execution:
+
+**`release`**
+It can be either `current_release` or `previous_release`, depending on which monthly tarball was downloaded.
+
+**`working_container`**
+ID of the container that was created. This value is dynamic to avoid collisions with any other container in the environment (e.g. previously created by this role).
 
 License
 -------

--- a/roles/arch_bootstrap/README.md
+++ b/roles/arch_bootstrap/README.md
@@ -1,7 +1,7 @@
 Arch Linux bootstrap
 ====================
 
-Role to download latest bootstrap tarball available for Arch Linux.
+Create an Arch Linux container from latest bootstrap tarball available.
 
 Role Variables
 --------------

--- a/roles/arch_bootstrap/README.md
+++ b/roles/arch_bootstrap/README.md
@@ -3,6 +3,13 @@ Arch Linux bootstrap
 
 Create an Arch Linux container from latest bootstrap tarball available.
 
+Requirements
+------------
+
+This role uses [`buildah`](https://github.com/containers/buildah/blob/master/install.md), a tool for building OCI images.
+
+Elevated privileges are needed to create root filesystems for containers.
+
 Role Variables
 --------------
 

--- a/roles/arch_bootstrap/defaults/main.yml
+++ b/roles/arch_bootstrap/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 base_url: https://archive.archlinux.org/iso
+path_to_bootstrap: "{{ playbook_dir }}/archlinux-bootstrap.tar.gz"

--- a/roles/arch_bootstrap/meta/main.yml
+++ b/roles/arch_bootstrap/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Miguel Casal
-  description: Role to download latest bootstrap tarball available for Arch Linux.
+  description: Create an Arch Linux container from latest bootstrap tarball available
   license: MIT
   min_ansible_version: 2.4
   galaxy_tags: []

--- a/roles/arch_bootstrap/tasks/download-tarball.yml
+++ b/roles/arch_bootstrap/tasks/download-tarball.yml
@@ -2,7 +2,7 @@
 - name: Download Arch Linux bootstrap tarball
   get_url:
     url: "{{ base_url }}/{{ date }}/archlinux-bootstrap-{{ date }}-x86_64.tar.gz"
-    dest: ./archlinux-bootstrap.tar.gz
+    dest: "{{ path_to_bootstrap }}"
     checksum: sha1:{{ base_url }}/{{ date }}/sha1sums.txt
   register: tarball_result
 - set_fact:

--- a/roles/arch_bootstrap/tasks/main.yml
+++ b/roles/arch_bootstrap/tasks/main.yml
@@ -14,8 +14,10 @@
 - name: Create an empty container
   command: buildah from scratch
   register: buildah_from
+- set_fact:
+    working_container: "{{ buildah_from.stdout }}"
 - name: Mount container's root filesystem
-  command: buildah mount {{ buildah_from.stdout }}
+  command: buildah mount {{ working_container }}
   register: buildah_mount
 - name: Extract bootstrap tarball to mount point
   unarchive:

--- a/roles/arch_bootstrap/tasks/main.yml
+++ b/roles/arch_bootstrap/tasks/main.yml
@@ -11,3 +11,14 @@
   vars:
     date: "{{ previous_release }}"
   when: tarball_result is failed
+- name: Create an empty container
+  command: buildah from scratch
+  register: buildah_from
+- name: Mount container's root filesystem
+  command: buildah mount {{ buildah_from.stdout }}
+  register: buildah_mount
+- name: Extract bootstrap tarball to mount point
+  unarchive:
+    src: ./archlinux-bootstrap.tar.gz
+    dest: "{{ buildah_mount.stdout }}"
+    extra_opts: [--strip-components=1]

--- a/roles/arch_bootstrap/tasks/main.yml
+++ b/roles/arch_bootstrap/tasks/main.yml
@@ -19,6 +19,6 @@
   register: buildah_mount
 - name: Extract bootstrap tarball to mount point
   unarchive:
-    src: ./archlinux-bootstrap.tar.gz
+    src: "{{ path_to_bootstrap }}"
     dest: "{{ buildah_mount.stdout }}"
     extra_opts: [--strip-components=1]


### PR DESCRIPTION
This role is a good place for all tasks related to container bootstrapping before tools and everything else is installed inside.