### PR TITLE
Trigger CI jobs manually on master branch to test changes on demand

### DIFF
--- a/.circleci/trigger-job.sh
+++ b/.circleci/trigger-job.sh
@@ -1,0 +1,3 @@
+curl -u ${CIRCLE_API_USER_TOKEN}: \
+     -d build_parameters[CIRCLE_JOB]=build_container \
+     https://circleci.com/api/v1.1/project/github/miquecg/elixir-ide/tree/master

--- a/.local/env
+++ b/.local/env
@@ -1,4 +1,5 @@
 # Source this file to load variables in the environment
+export CIRCLE_API_USER_TOKEN=
 export IMAGE_NAME=
 export REGISTRY_HOST=
 export REGISTRY_USER=


### PR DESCRIPTION
Whenever there's a change on a role that this project depends on, we should trigger a new build. For the moment it will be enough to provide a script for doing that.

Ideally the CI platform should provide a way to link different projects together. This will require a bit more of research.