### PR TITLE
Container networking is enabled by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,6 @@ commands:
           name: << parameters.task-name >>
           command: >
             docker run
-            --net=host
             --privileged
             -v ~/mycontainer:/var/lib/containers:Z
             -v ~/project:${BUILD_DIR}


### PR DESCRIPTION
> By default, all containers have networking enabled and they can make any outgoing connections.

https://docs.docker.com/engine/reference/run/#network-settings