### PR TITLE
CI failure because of new python-gilt dependency on Python 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ commands:
             - run:
                 name: Pull roles from repository
                 command: |
-                  pyenv versions
+                  pyenv global 3.7.0
                   pip install python-gilt
                   gilt overlay
   docker-run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ commands:
             - run:
                 name: Pull roles from repository
                 command: |
+                  pyenv versions
                   pip install python-gilt
                   gilt overlay
   docker-run:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/opt/circleci/.pyenv/versions/2.7.12/bin/gilt", line 7, in <module>
    from gilt.shell import main
  File "/opt/circleci/.pyenv/versions/2.7.12/lib/python2.7/site-packages/gilt/shell.py", line 27, in <module>
    from gilt import config
  File "/opt/circleci/.pyenv/versions/2.7.12/lib/python2.7/site-packages/gilt/config.py", line 24, in <module>
    import urllib.parse
ImportError: No module named parse
```

### Source
https://github.com/retr0h/gilt/pull/73

`urllib.parse` is a Python 3 module.